### PR TITLE
Add Trolley to e-commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@
 
 ## Videos
 
-<!-- - [The New Front-end Stack. JavaScript, APIs and Markup](https://vimeo.com/163522126) - Matt Biilmann. -->
+- [The New Front-end Stack. JavaScript, APIs and Markup](https://vimeo.com/163522126) - Matt Biilmann.
 - [Rise of the JAMstack](https://www.youtube.com/watch?v=uWTMEDEPw8c) - Mathias Biillman.
 - [Git-based or API-driven CMS](https://www.youtube.com/watch?v=KX4G49ZrvY0) - Chris Macrae.
 - [JAMstack Tutorial - Full site using Netlify & Hugo](https://www.youtube.com/watch?v=NSts93C9UeE) - freeCodeCamp.org.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [GoCommerce](https://www.gocommerceapi.org) - A headless e-commerce for JAMstack sites.
 - [Snipcart](https://snipcart.com/) - A powerful shopping cart platform for developers.
 - [Moltin](https://moltin.com/) - eCommerce API for developers.
+- [Trolley](https://trolley.link) - a shopping cart designed for the JAMstack
 
 ### Search
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@
 - [GoCommerce](https://www.gocommerceapi.org) - A headless e-commerce for JAMstack sites.
 - [Snipcart](https://snipcart.com/) - A powerful shopping cart platform for developers.
 - [Moltin](https://moltin.com/) - eCommerce API for developers.
-- [Trolley](https://trolley.link) - a shopping cart designed for the JAMstack
+- [Trolley](https://trolley.link) - a shopping cart designed for the JAMstack.
 
 ### Search
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@
 - [GoCommerce](https://www.gocommerceapi.org) - A headless e-commerce for JAMstack sites.
 - [Snipcart](https://snipcart.com/) - A powerful shopping cart platform for developers.
 - [Moltin](https://moltin.com/) - eCommerce API for developers.
-- [Trolley](https://trolley.link) - a shopping cart designed for the JAMstack.
+- [Trolley](https://trolley.link) - A shopping cart designed for the JAMstack.
 
 ### Search
 
@@ -172,7 +172,7 @@
 
 ## Videos
 
-- [The New Front-end Stack. JavaScript, APIs and Markup](https://vimeo.com/163522126) - Matt Biilmann.
+<!-- - [The New Front-end Stack. JavaScript, APIs and Markup](https://vimeo.com/163522126) - Matt Biilmann. -->
 - [Rise of the JAMstack](https://www.youtube.com/watch?v=uWTMEDEPw8c) - Mathias Biillman.
 - [Git-based or API-driven CMS](https://www.youtube.com/watch?v=KX4G49ZrvY0) - Chris Macrae.
 - [JAMstack Tutorial - Full site using Netlify & Hugo](https://www.youtube.com/watch?v=NSts93C9UeE) - freeCodeCamp.org.


### PR DESCRIPTION
Adding Trolley (https://trolley.link) as a shopping cart - it's deliberately designed to work with the JAMstack !