### PR TITLE
Change "JAMstack" to "Jamstack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
   <br /><br />
   <a href="https://awesome.re"><img src="https://awesome.re/badge-flat.svg" /></a>
   <br /><br /><br />
-  <img width="500" src="media/jamstack-full-logo.svg" alt="JAMstack">
+  <img width="500" src="media/jamstack-full-logo.svg" alt="Jamstack">
   <br /><br /><br />
   <p>
-    <strong>JAMstack</strong>: noun \’jam-stak’\<br />
+    <strong>Jamstack</strong>: noun \’jam-stak’\<br />
     Modern web development architecture based on client-side JavaScript, reusable APIs, and prebuilt Markup.
   </p>
   <br /><br />
   <p>
     <b>
-      This is a carefully curated list of awesome <a href="https://jamstack.org">JAMstack</a> resources.
+      This is a carefully curated list of awesome <a href="https://jamstack.org">Jamstack</a> resources.
     </b>
   </p>
   <br /><br />
@@ -33,7 +33,7 @@
 - [General](#general)
 - [Chats](#chats)
 - [Platforms](#platforms)
-- [JAMstack Sites Showcase](#jamstack-sites-showcase)
+- [Jamstack Sites Showcase](#jamstack-sites-showcase)
 - [Static Site Generators](#static-site-generators)
 - [CMS](#cms)
 - [API](#api)
@@ -54,14 +54,14 @@
 
 ## General
 
-- [JAMstack](https://jamstack.org/)
-- [JAMstack resources](https://jamstack.org/resources/) - Videos and articles about JAMstack.
-- [the New Dynamic](https://www.thenewdynamic.org/) - Pick up tools in our Directory to work with the JAMstack. Browse our showcase and get inspired.
+- [Jamstack](https://jamstack.org/)
+- [Jamstack resources](https://jamstack.org/resources/) - Videos and articles about Jamstack.
+- [the New Dynamic](https://www.thenewdynamic.org/) - Pick up tools in our Directory to work with the Jamstack. Browse our showcase and get inspired.
 
 ## Chats
 
 - [Appernetic Gitter Chat](https://gitter.im/appernetic/issues)
-- [JAMstack Gitter Chat](https://gitter.im/jamstack/community)
+- [Jamstack Gitter Chat](https://gitter.im/jamstack/community)
 - [Netlify Gitter Chat](https://gitter.im/netlify/community)
 - [NetlifyCMS Gitter Chat](https://gitter.im/netlify/NetlifyCMS)
 - [the New Dynamic Slack](https://join.slack.com/t/thenewdynamic/shared_invite/enQtMjkwNjYwNTY0NjkxLWI1NDhlNjZkZjA5ZGJmODE1OThiMjkwN2ZkMzE1YjEwN2YwNWUxYTNjZTUxMGQ2MzU3NWQ0YmVjNGU1NTkxMDk)
@@ -72,7 +72,7 @@
 - [Netlify](https://netlify.com) - All-in-one platform for automating modern web projects.
 - [ZEIT Now](https://zeit.co) - All-in-one serverless platform for modern web apps with config-free tools and workflows.
 
-## JAMstack Sites Showcase
+## Jamstack Sites Showcase
 
 - [React](https://reactjs.org/) - Built on Gatsby.
 - [Squoosh.app](https://squoosh.app/) - Hosted on Netlify, demonstrates advanced features from a modern Web Application.
@@ -113,7 +113,7 @@
 - [Forestry](https://forestry.io) - Headless CMS for sites built with static site generators.
 - [Coisas](https://github.com/fiatjaf/coisas) - A client-side CMS for editing GitHub Markdown (and other) files.
 - [Cockpit](https://getcockpit.com/) - A self-hosted headless and api-driven CMS.
-- [HeadlessCMS](https://headlesscms.org/) - A List of Content Management Systems for JAMstack Sites.
+- [HeadlessCMS](https://headlesscms.org/) - A List of Content Management Systems for Jamstack Sites.
 - [TakeShape](https://www.takeshape.io/) - Headless GraphQL API CMS with 1-click deploy to Netlify.
 - [Ghost](https://ghost.org/) - A headless CMS for online publications
 - [Strapi](https://strapi.io) - The open source Headless CMS Front-End Developers love.
@@ -139,10 +139,10 @@
 ### E-commerce
 
 - [Flatmarket](https://github.com/christophercliff/flatmarket) - Flatmarket is a free, open source e-commerce platform for static websites.
-- [GoCommerce](https://www.gocommerceapi.org) - A headless e-commerce for JAMstack sites.
+- [GoCommerce](https://www.gocommerceapi.org) - A headless e-commerce for Jamstack sites.
 - [Snipcart](https://snipcart.com/) - A powerful shopping cart platform for developers.
 - [Moltin](https://moltin.com/) - eCommerce API for developers.
-- [Trolley](https://trolley.link) - A shopping cart designed for the JAMstack.
+- [Trolley](https://trolley.link) - A shopping cart designed for the Jamstack.
 - [Shopify](https://www.shopify.co.uk/plus/solutions/headless-commerce) - Shopify headless e-commerce solution.
 
 ### Search
@@ -181,56 +181,56 @@
   - [BigQuery](https://cloud.google.com/bigquery/) - Serverless data warehousing services that help you to deploy advanced cloud data warehousing solutions for your enterprise.
   - [Cloud ML Engine](https://cloud.google.com/ml-engine/) - Serverless machine learning services that automatically scales built on custom Google hardware (Tensor Processing Units).
 - [Serverless](https://serverless.com/) - Toolkit for deploying and operating serverless architectures.
-- [Cloudinary](https://cloudinary.com/) - Serverless media (images/videos) management platform. Provides SDKs in every popular language and media widgets for JAMstack to make it easy to manage media, CDN, storage, transformations, and more.
+- [Cloudinary](https://cloudinary.com/) - Serverless media (images/videos) management platform. Provides SDKs in every popular language and media widgets for Jamstack to make it easy to manage media, CDN, storage, transformations, and more.
 
 *For a more complete list see [Awesome Serverless](https://github.com/pmuens/awesome-serverless).*
 
 ## Videos
 
 - [The New Front-end Stack. JavaScript, APIs and Markup](https://vimeo.com/163522126) - Matt Biilmann.
-- [Rise of the JAMstack](https://www.youtube.com/watch?v=uWTMEDEPw8c) - Mathias Biillman.
-- [JAMstack: Silly name, serious stuff](https://www.youtube.com/watch?v=XOYtS91QWQI) - Phil Hawksworth.
+- [Rise of the Jamstack](https://www.youtube.com/watch?v=uWTMEDEPw8c) - Mathias Biillman.
+- [Jamstack: Silly name, serious stuff](https://www.youtube.com/watch?v=XOYtS91QWQI) - Phil Hawksworth.
 - [Git-based or API-driven CMS](https://www.youtube.com/watch?v=KX4G49ZrvY0) - Chris Macrae.
-- [JAMstack Tutorial - Full site using Netlify & Hugo](https://www.youtube.com/watch?v=NSts93C9UeE) - freeCodeCamp.org.
+- [Jamstack Tutorial - Full site using Netlify & Hugo](https://www.youtube.com/watch?v=NSts93C9UeE) - freeCodeCamp.org.
 - [Gatsby JS Crash Course](https://www.youtube.com/watch?v=6YhqQ2ZW1sc) - Traversy Media.
 - [How We Got Here and The Future of the Web](https://www.gatsbyjs.com/gatsby-days-keynote-kyle/) - Kyle Mathews.
-- [Talks from all the JAMstack Conferences](https://www.youtube.com/channel/UC8bRyfU7ycLXnEBfvdorpUg/videos) - JAMstack Conf.
-- [How I Used React, Vue, & Node to Build a Single JAMstack App](https://www.youtube.com/watch?v=dwpn1pd9kT8) - Ahmad Awais.
+- [Talks from all the Jamstack Conferences](https://www.youtube.com/channel/UC8bRyfU7ycLXnEBfvdorpUg/videos) - Jamstack Conf.
+- [How I Used React, Vue, & Node to Build a Single Jamstack App](https://www.youtube.com/watch?v=dwpn1pd9kT8) - Ahmad Awais.
 
 ## Tutorials / Articles
 
-- [Ghost on the JAMstack](https://blog.ghost.org/jamstack/)
+- [Ghost on the Jamstack](https://blog.ghost.org/jamstack/)
 - [Building a contact form in Gatsby using Getform](https://blog.getform.io/building-a-gatsby-contact-form-using-getform)
 - [Getting Started with Gatsby and Cockpit — Part 1 of 2](https://blog.ginetta.net/getting-started-with-gatsby-and-cockpit-part-1-of-2-d86871932d44)
 - [Creating Static E-commerce site with GatsbyJs](https://medium.com/@pinku1/creating-static-e-commerce-site-with-gatsbyjs-a349d7e022a)
 - [For Static Sites, There’s No Excuse Not to Use a CDN](https://forestry.io/blog/for-static-sites-theres-no-excuse-not-to-use-a-cdn/)
 - [E-commerce front-end for Vue.js, Nuxt.js and Snipcart](https://www.sanity.io/blog/e-commerce-vue-nuxt-snipcart)
 - [Building Paul The Octopus](https://www.tomango.co.uk/thinks/paul-the-octopus-2018/)
-- [JAMstack and Netlify: Do We really need another buzzword?](https://noti.st/philhawksworth/qp7jZC/jamstack-and-netlify-do-we-really-need-another-buzzword)
-- [The JAMstack Startup Landscape](https://medium.com/@CRVVC/the-jamstack-startup-landscape-c06cc3cdb917)
+- [Jamstack and Netlify: Do We really need another buzzword?](https://noti.st/philhawksworth/qp7jZC/jamstack-and-netlify-do-we-really-need-another-buzzword)
+- [The Jamstack Startup Landscape](https://medium.com/@CRVVC/the-jamstack-startup-landscape-c06cc3cdb917)
 - [How I built my blog using Gatsby and Netlify](https://blog.pavsidhu.com/how-i-built-my-blog-using-gatsby-and-netlify/)
 - [Developer's Guide to Headless E-Commerce](https://snipcart.com/blog/headless-ecommerce-guide)
 - [Handling Static Forms, Auth & Serverless Functions with Gatsby on Netlify](https://snipcart.com/blog/static-forms-serverless-gatsby-netlify)
-- [JAMstack for Clients: Benefits, Static Site CMS, & Limitations](https://snipcart.com/blog/jamstack-clients-static-site-cms)
+- [Jamstack for Clients: Benefits, Static Site CMS, & Limitations](https://snipcart.com/blog/jamstack-clients-static-site-cms)
 - [Exploring Netlify CMS, a React & Git-Based Content Management System](https://snipcart.com/blog/netlify-cms-react-git-workflow)
-- [JAMstack PWA — Let’s Build a Polling App. with Gatsby.js, Firebase, and Styled-components Pt. 1](https://medium.com/@UnicornAgency/jamstack-pwa-lets-build-a-polling-app-with-gatsby-js-firebase-and-styled-components-pt-1-78a03a633092)
+- [Jamstack PWA — Let’s Build a Polling App. with Gatsby.js, Firebase, and Styled-components Pt. 1](https://medium.com/@UnicornAgency/jamstack-pwa-lets-build-a-polling-app-with-gatsby-js-firebase-and-styled-components-pt-1-78a03a633092)
 - [Dynamic Static Sites with Netlify and iOS Shortcuts; Use Netlify Functions, a Gulp build process and iOS Shortcuts to publish dynamic content to your static site](https://bryanlrobinson.com/blog/2018/11/12/ios-shortcuts-pushing-data-to-netlify-static-site/)
 - [Gatsby for Apps](https://www.gatsbyjs.org/blog/2018-11-07-gatsby-for-apps/)
 - [Turning the Static Dynamic](https://www.gatsbyjs.org/blog/2018-12-17-turning-the-static-dynamic/)
-- [Going JAMstack with Netlify and Nuxt](https://blog.lichter.io/posts/going-jamstack-with-netlify-and-nuxt/)
+- [Going Jamstack with Netlify and Nuxt](https://blog.lichter.io/posts/going-jamstack-with-netlify-and-nuxt/)
 - [Getting Started With Gridsome](https://scotch.io/tutorials/getting-started-with-gridsome)
 - [The Complete Beginner's Guide to Deploying Your First Static Website to IPFS](https://interplanetarygatsby.com/ipfs-deploy/)
-- [A Broad Discussion on JAMstack & E-Commerce (Podcast & Transcript)](https://snipcart.com/jamstack-ecommerce-podcast)
+- [A Broad Discussion on Jamstack & E-Commerce (Podcast & Transcript)](https://snipcart.com/jamstack-ecommerce-podcast)
 - [The Beginner's Guide to Static Site Generators](https://bejamas.io/blog/static-site-generators/)
-- [9 Headless CMS Options for Your JAMstack Site](https://bejamas.io/blog/headless-cms/)
+- [9 Headless CMS Options for Your Jamstack Site](https://bejamas.io/blog/headless-cms/)
 
 ## Podcasts
 
-- [JAMstack Radio](https://www.netlify.com/tags/podcast/)
-- [That's my JAMstack](https://thatsmyjamstack.com)
+- [Jamstack Radio](https://www.netlify.com/tags/podcast/)
+- [That's my Jamstack](https://thatsmyjamstack.com)
 
 ## Books
-- [Modern Web Development on the JAMstack](https://www.netlify.com/pdf/oreilly-modern-web-development-on-the-jamstack.pdf) - By Mathias Biilmann & Phil Hawksworth (published by O'Reilly).
+- [Modern Web Development on the Jamstack](https://www.netlify.com/pdf/oreilly-modern-web-development-on-the-jamstack.pdf) - By Mathias Biilmann & Phil Hawksworth (published by O'Reilly).
 - [Hugo in Action](https://www.manning.com/books/hugo-in-action)
 
 ## License


### PR DESCRIPTION
Change the capitalization of "JAMstack" to Titlecase ("Jamstack") following the new accepted wording by https://jamstack.org/

**Reference:**
[The original discusstion at jamstack/jamstack.org](https://github.com/jamstack/jamstack.org/issues/279?utm_campaign=Netlify+Newsletter+-+April+2020+-+3&utm_content=Netlify+Newsletter+-+April+2020+B&utm_medium=email_action&utm_source=customer.io#issuecomment-607896059)