### PR TITLE
Add Kentico Kontent into the list of Jamstack CMSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@
 *For a more complete list see [StaticGen](https://www.staticgen.com/).*
 
 ## CMS
-
+- [Kentico Kontent](https://kontent.ai) - A cloud-native headless CMS that scales.
 - [Contentful](https://contentful.com) - Content infrastructure for digital teams.
 - [NetlifyCMS](https://netlifycms.org/) - open source Git-based CMS.
 - [ButterCMS](https://buttercms.com/) - Headless CMS and Content API.


### PR DESCRIPTION
Kentico Kontent is a cloud-based headless CMS for Jamstack