### PR TITLE
Add Stormkit to Serverless sublist

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
 - [Cloudinary](https://cloudinary.com/) - Serverless media (images/videos) management platform. Provides SDKs in every popular language and media widgets for Jamstack to make it easy to manage media, CDN, storage, transformations, and more.
 - [imgix](https://www.imgix.com/) - Serverless image delivery and management service.  imgix connects to where your images are stored (e.g. S3, GCS, web folder) and transforms, optimizes, and intelligently delivers your images using simple and robust URL parameters.
 - [Elastictable](https://www.elastictable.com) - Backend as a Service solution built on AWS that's on a missing to increase the success rate of online businesses. 
+- [Stormkit](https://stormkit.io) - Powerful serverless infrastructure for modern javascript apps powered by AWS. It integrates with your git flow and builds, deploys and scales your apps seamlessly.
 
 *For a more complete list see [Awesome Serverless](https://github.com/pmuens/awesome-serverless).*
 


### PR DESCRIPTION
It might also fit into the Platforms sublist. As Stormkit orchestrates AWS services and based on the elements in the sublist Serverless, I believe it fits best in there.