### PR TITLE
Add Layer0 to Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [Appernetic](https://appernetic.io) - Visual content management for static web sites, with Hugo and GitHub Pages.
 - [Netlify](https://netlify.com) - All-in-one platform for automating modern web projects.
 - [Vercel](https://vercel.com) - All-in-one serverless platform for modern web apps with config-free tools and workflows.
+- [Layer0](https://layer0.co) - All-in-one Jamscak platform focused on large, dynamic websites and best-in-class performance through an integrated CDN, EdgeJS, predictive prefetching, and performance monitoring.
 
 
 ## No-Code Platforms


### PR DESCRIPTION
Layer0 supports multiple Jamstack frameworks with a focus on large websites and ecommerce: https://docs.layer0.co