### PR TITLE
Added Corbado to API > Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 - [Netlify Identity](https://www.netlify.com/docs/identity/) - Brings a full suite of authentication functionality, backed by the [GoTrue API](https://www.gotrueapi.org).
 - [Stytch](https://stytch.com) - Passwordless authentication and session management API, try it out [on Vercel](https://github.com/vercel/next.js/tree/canary/examples/auth-with-stytch).
 - [Clerk](https://clerk.com) – Complete user management UIs and APIs, purpose-built for React, Next.js, and the modern web.
+- [Corbado](https://corbado.com) – Passwordless authentication & IAM for the modern tech stack - with a forever-free community plan.
 
 ### Comments
 


### PR DESCRIPTION
Corbado provides similar services to Stytch & Clerk, but focusing on passkey-first authentication.
They offer solutions for all major frameworks and also post a lot of educational content, which is why they should be included.