### PR TITLE
Add DishRoll to Jamstack Sites Showcase section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ _For more resources about Static Web Apps see (Awesome Static Web Apps)[https://
 - [Creative Designs Guru](https://creativedesignsguru.com) - Built on Eleventy.js hosted on Netlify and styled with Tailwind CSS
 - [HandleDroid](https://handledroid.com/) - Built with Next.js, MongoDB, Auth0, AWS CloudWatch, SendGrid, Stripe and hosted on Netlify.
 - [Backlinko](https://bejamas.io/blog/backlinko-case-study/) - Built with Next.js, headless WordPress and Netlify.
+- [DishRoll](https://dishroll.netlify.app/) - AI-powered weekly meal planner built with React 18 and Vite, using Netlify Functions and Claude Sonnet API.
 
 ## Static Site Generators
 


### PR DESCRIPTION
Adding DishRoll to the Jamstack Sites Showcase section.

- **Name:** DishRoll
- - **URL:** https://dishroll.netlify.app/
- - **Tech stack:** React 18, Vite, Netlify Functions, Claude Sonnet (Anthropic API)
- - **Hosted on:** Netlify
- - **License:** MIT (open-source)
DishRoll is an AI-powered weekly meal planner that generates personalized 7-day menus based on cuisine preferences, dietary needs, and budget. It fits the Jamstack Sites Showcase as a React + Vite app deployed on Netlify with serverless functions.