### PR TITLE
Add Mandu — agent-native fullstack framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ _For more resources about Static Web Apps see (Awesome Static Web Apps)[https://
 - [Nift](https://nift.dev) - A cross-platform open source website generator developed in C++ that is lightning fast and extremely powerful.
 - [Astro](https://astro.build) - Build faster websites, while shipping less to almost no Javascript.
 - [FactorJS](https://www.factorjs.org) - Next-generation framework powered by Vite.
+- [Mandu](https://mandujs.com) - Agent-native fullstack framework on Bun + React. Static export, SSR, file-system routing, runtime architecture guard, and 100+ MCP tools so AI editors can drive the site end-to-end.
 
 _For a more complete list see [StaticGen](https://www.staticgen.com/)._
 


### PR DESCRIPTION
Adds [Mandu](https://mandujs.com) under **Static Site Generators**, alongside Gatsby, Next.js, Astro, FactorJS, etc.

Mandu is a Bun-native, React-based fullstack framework that supports both static export and SSR:

- File-system routing under `app/**/page.tsx`, `.island.tsx` for client hydration
- Static prerender (`mandu build --static`) emits a fully-static `dist/` deployable to any CDN — Vercel, Cloudflare Pages, Netlify, Fly, Railway, Docker, plain S3 + CloudFront
- Runtime architecture **Guard** rejects layer/import violations as the dev server runs
- **Contract-first APIs** — one zod-shaped contract → TS types + validation + OpenAPI
- 100+ MCP tools so AI editors (Claude Code / Cursor / OpenAI Codex / GitHub Copilot) can drive scaffolding, deploys, etc. without leaving the chat

Site / docs: https://mandujs.com  ·  source: https://github.com/konamgil/mandu

Happy to revise the description if it should be tighter to match neighbouring entries.