### PR TITLE
Add Bloggrify, and update the StaticGen link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ _For more resources about Static Web Apps see (Awesome Static Web Apps)[https://
 - [Astro](https://astro.build) - Build faster websites, while shipping less to almost no Javascript.
 - [FactorJS](https://www.factorjs.org) - Next-generation framework powered by Vite.
 - [Mandu](https://mandujs.com) - Agent-native fullstack framework on Bun + React. Static export, SSR, file-system routing, runtime architecture guard, and 100+ MCP tools so AI editors can drive the site end-to-end.
+- [Bloggrify](https://bloggrify.com) - Nuxt Content layer for blogging, with themes, SEO, RSS and analytics preconfigured.
 
-_For a more complete list see [StaticGen](https://www.staticgen.com/)._
+_For a more complete list see [Jamstack generators](https://jamstack.org/generators/)._
 
 ## CMS
 


### PR DESCRIPTION
Two changes:

**Adds Bloggrify** to Static Site Generators. It is a Nuxt layer for blogging, built on Nuxt Content and Nuxt UI, handling posts, archives, tags, categories and authors, plus SEO, RSS, search, and analytics, newsletter and comment integrations. MIT licensed. Repository: https://github.com/bloggrify/bloggrify

**Updates the StaticGen link.** StaticGen was archived in 2020 and staticgen.com now redirects to jamstack.org/generators. The link still works through the redirect, but pointing at the current URL is clearer for readers.

Disclosure: I maintain Bloggrify.
