### PR TITLE
Add Nhost to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ _For a more complete list see [StaticGen](https://www.staticgen.com/)._
 - [Fireproof](https://use-fireproof.com/) - Zero dependency, offline-capable CRDT database, runs in the browser and connects to any cloud.
 - [Jexia DataSet](https://jexia.com) - REST API Schema & Schemaless cloud data storage with built-in validators, relations, aggregation functions.
 - [Tigris](https://www.tigrisdata.com) - Open-source data platform with databases, automatic search indexing for real-time search, caching and real-time pub/sub.
+- [Nhost](https://nhost.io) - Open-source backend-as-a-service with a Postgres database, instant Hasura GraphQL API, authentication, storage, and serverless functions.
 
 ### File management
 


### PR DESCRIPTION
Adds [Nhost](https://nhost.io) to the Database section, next to Graphcool and other backend-as-a-service entries.

Nhost is an open-source (MIT) backend-as-a-service: a Postgres database, an instant Hasura GraphQL API, authentication, file storage, and serverless functions. It's a common backend/data layer for Jamstack frontends, so it fits alongside Graphcool and FaunaDB.

Project: https://nhost.io
Source code: https://github.com/nhost/nhost

One suggestion, added to the bottom of the section, format and casing per the contribution guidelines.