### PR TITLE
Update Getform branding to Forminit

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ _For a more complete list see [StaticGen](https://www.staticgen.com/)._
 - [Fetch Forms](https://www.fetchforms.io/) - Create forms with the speed of a form builder and use them in your applications by calling a simple API.
 - [Formcarry](https://formcarry.com) - Hassle-free HTML form endpoints for your form, powerful dashboard, reliable spam blocking, attachment uploads and Zapier integrations.
 - [Formcake](https://formcake.com) - A form backend built for developers: Zapier integrations, zero dependencies, a simple API, and unlimited forms.
-- [Getform](https://getform.io) - Form backend platform for designers and developers. Setup your form endpoints for your static site within minutes and expand your data with Zapier integration and Webhooks support.
+- [Forminit](https://forminit.com) - Headless form backend for developers and agents. The free plan allows 100 form submissions per month including file uploads, server-side field validation, email notifications, spam protection.
 - [Netlify Forms](https://www.netlify.com/docs/form-handling/) - Built-in form handling on building time by parsing HTML files directly at deploy time.
 - [Arengu](https://www.arengu.com) - Build signup and login forms with Arengu, enable social login, add 2FA or use passwordless flows to authenticate users with your API or identity provider.
 - [Static Forms](https://www.staticforms.xyz/) - Integrate HTML forms easily without any server side code. After user submits the form we'll send you content of the form to your registered email.


### PR DESCRIPTION
Replace Getform with Forminit in the Forms resources list and update the website URL from getform.io to forminit.com following the product rebrand.

Related announcement: https://forminit.com/blog/getform-is-now-forminit/