### PR TITLE
Add Silex to No-Code Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _For more resources about Static Web Apps see (Awesome Static Web Apps)[https://
 - [Draftbox](https://draftbox.co) - Lightning fast, secure front-end for your WordPress or Ghost blog, without coding.
 - [Plasmic](https://www.plasmic.app/) - Powerful design tool for building your React components and Jamstack websites visually.
 - [TeleportHQ](https://teleporthq.io/) - Front-end Design & Development Platform. TeleportHQ is the collaborative front-end platform to create and publish your headless static websites instantly. Free code export, 3 free projects, unlimited collaborators.
+- [Silex](https://www.silex.me) - Visual website builder that outputs static HTML and CSS. Connects to any headless CMS, self-hostable, no lock-in.
 
 ## Jamstack Sites Showcase
 


### PR DESCRIPTION
Adding [Silex](https://www.silex.me) to the No-Code Platforms section.

Silex is a free and open source visual website builder (AGPL-3.0, [source](https://github.com/silexlabs/Silex)). It outputs plain static HTML and CSS, connects to any headless CMS for dynamic data, and can be self-hosted, so there is no platform lock-in. It fits alongside Plasmic and TeleportHQ in that section, and it carries the `jamstack` topic on its own repository.

I maintain the project. It has been around since 2013, is actively developed (v3.9.0 released in July 2026), and part of the current work is funded by the NGI0 Commons Fund. Live demo: https://v3.silex.me

Guidelines checked: single suggestion, added at the bottom of the section, format `[name](link) - Description.`, description short and ending with a period.